### PR TITLE
feat: add signup page and steps form multi step form

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,6 +1,7 @@
 export default {
   preset: 'ts-jest',
   testEnvironment: 'jsdom',
+  setupFilesAfterEnv: ['<rootDir>/src/setupTests.ts'],
   moduleNameMapper: {
     '\\.(css|less|scss|sass)$': 'identity-obj-proxy',
     '\\.(svg|png|jpg|jpeg|gif)$': '<rootDir>/__mocks__/fileMock.ts',

--- a/src/features/auth/pages/signup/__tests__/index.spec.tsx
+++ b/src/features/auth/pages/signup/__tests__/index.spec.tsx
@@ -1,0 +1,51 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { Signup } from '../';
+
+describe('Signup', () => {
+  it('deve renderizar o stepper com todos os passos', () => {
+    render(<Signup />);
+
+    expect(screen.getByText(/Informações Pessoais/i)).toBeInTheDocument();
+    expect(screen.getByText(/Dados de Acesso/i)).toBeInTheDocument();
+    expect(screen.getByText(/Confirmação/i)).toBeInTheDocument();
+  });
+
+  it('deve renderizar o conteúdo do primeiro passo (AccountStep)', () => {
+    render(<Signup />);
+    expect(screen.getByLabelText(/Nome/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Email/i)).toBeInTheDocument();
+    expect(screen.getAllByLabelText(/Senha/i)[0]).toBeInTheDocument();
+  });
+
+  it('deve avançar para o próximo passo ao clicar em Próximo', () => {
+    render(<Signup />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Próximo/i }));
+
+    expect(screen.getByLabelText(/Rua/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Cidade/i)).toBeInTheDocument();
+  });
+
+  it('deve voltar para o passo anterior ao clicar em Voltar', () => {
+    render(<Signup />);
+
+    // avança para step 1
+    fireEvent.click(screen.getByRole('button', { name: /Próximo/i }));
+    expect(screen.getByLabelText(/Rua/i)).toBeInTheDocument();
+
+    // volta para step 0
+    fireEvent.click(screen.getByRole('button', { name: /Voltar/i }));
+    expect(screen.getByLabelText(/Nome/i)).toBeInTheDocument();
+  });
+
+  it('deve exibir o botão Finalizar no último passo', () => {
+    render(<Signup />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Próximo/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Próximo/i }));
+    expect(screen.getByLabelText(/Link do Github/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /Finalizar/i }),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/features/auth/pages/signup/components/accountStep/__tests__/index.spec.tsx
+++ b/src/features/auth/pages/signup/components/accountStep/__tests__/index.spec.tsx
@@ -1,0 +1,63 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { AccountStep } from '../';
+
+describe('AccountStep', () => {
+  const mockOnChange = jest.fn();
+  const defaultData = {
+    name: 'Gustavo',
+    email: 'gustavo@example.com',
+    password: '123456',
+    address: '',
+    number: '',
+    complement: '',
+    neighborhood: '',
+    city: '',
+    state: '',
+    zipCode: '',
+    country: '',
+    githubLink: '',
+    linkedinLink: '',
+    bio: '',
+    stack: [],
+    confirmPassword: '14333241',
+  };
+
+  beforeEach(() => {
+    mockOnChange.mockClear();
+  });
+
+  it('deve renderizar os campos de texto com labels corretos', () => {
+    render(<AccountStep onChange={mockOnChange} data={defaultData} />);
+
+    expect(screen.getByLabelText(/Nome/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Email/i)).toBeInTheDocument();
+    expect(screen.getAllByLabelText(/Senha/i)).toHaveLength(2);
+  });
+
+  it('deve exibir os valores iniciais corretamente', () => {
+    render(<AccountStep onChange={mockOnChange} data={defaultData} />);
+
+    expect(screen.getByLabelText(/Nome/i)).toHaveValue('Gustavo');
+    expect(screen.getByLabelText(/Email/i)).toHaveValue('gustavo@example.com');
+    expect(screen.getAllByLabelText(/Senha/i)[0]).toHaveValue('123456');
+  });
+
+  it('deve chamar onChange ao digitar nos campos', () => {
+    render(<AccountStep onChange={mockOnChange} data={defaultData} />);
+
+    const nomeInput = screen.getByLabelText(/Nome/i);
+    fireEvent.change(nomeInput, { target: { value: 'Akira' } });
+
+    expect(mockOnChange).toHaveBeenCalledWith('name', 'Akira');
+
+    const emailInput = screen.getByLabelText(/Email/i);
+    fireEvent.change(emailInput, { target: { value: 'akira@example.com' } });
+
+    expect(mockOnChange).toHaveBeenCalledWith('email', 'akira@example.com');
+
+    const senhaInput = screen.getAllByLabelText(/Senha/i)[0];
+    fireEvent.change(senhaInput, { target: { value: 'novaSenha' } });
+
+    expect(mockOnChange).toHaveBeenCalledWith('password', 'novaSenha');
+  });
+});

--- a/src/features/auth/pages/signup/components/accountStep/index.tsx
+++ b/src/features/auth/pages/signup/components/accountStep/index.tsx
@@ -1,0 +1,39 @@
+import { TextField } from '@mui/material';
+import type { FormStepProps } from '../../interface';
+
+export const AccountStep = ({ onChange, data }: FormStepProps) => {
+  return (
+    <>
+      <TextField
+        value={data.name}
+        label="Nome"
+        onChange={(e) => onChange('name', e.target.value)}
+        required
+      />
+      <TextField
+        type="email"
+        name="email"
+        value={data.email}
+        onChange={(e) => onChange('email', e.target.value)}
+        label="Email"
+        required
+      />
+      <TextField
+        type="password"
+        value={data.password}
+        name="password"
+        label="Senha"
+        onChange={(e) => onChange('password', e.target.value)}
+        required
+      />
+      <TextField
+        type="password"
+        value={data.confirmPassword}
+        name="confirmPassword"
+        label="Confirmar Senha"
+        onChange={(e) => onChange('confirmPassword', e.target.value)}
+        required
+      />
+    </>
+  );
+};

--- a/src/features/auth/pages/signup/components/addressStep/__tests__/index.spec.tsx
+++ b/src/features/auth/pages/signup/components/addressStep/__tests__/index.spec.tsx
@@ -1,0 +1,90 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { AddressStep } from '../';
+
+describe('AddressStep', () => {
+  const mockOnChange = jest.fn();
+  const defaultData = {
+    address: 'Rua das Acácias',
+    city: 'São Paulo',
+    number: '123',
+    neighborhood: 'Centro',
+    state: 'SP',
+    zipCode: '01234-567',
+    country: 'Brasil',
+    name: 'Gustavo',
+    email: 'gustavo@example.com',
+    password: '123456',
+    githubLink: '',
+    linkedinLink: '',
+    bio: '',
+    stack: [],
+    confirmPassword: '14333241',
+  };
+
+  beforeEach(() => {
+    mockOnChange.mockClear();
+  });
+
+  it('deve renderizar todos os campos com labels corretos', () => {
+    render(<AddressStep onChange={mockOnChange} data={defaultData} />);
+
+    expect(screen.getByLabelText(/Rua/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Cidade/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Número/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Bairro/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Estado/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/CEP/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/País/i)).toBeInTheDocument();
+  });
+
+  it('deve exibir os valores iniciais corretamente', () => {
+    render(<AddressStep onChange={mockOnChange} data={defaultData} />);
+
+    expect(screen.getByLabelText(/Rua/i)).toHaveValue('Rua das Acácias');
+    expect(screen.getByLabelText(/Cidade/i)).toHaveValue('São Paulo');
+    expect(screen.getByLabelText(/Número/i)).toHaveValue('123');
+    expect(screen.getByLabelText(/Bairro/i)).toHaveValue('Centro');
+    expect(screen.getByLabelText(/Estado/i)).toHaveValue('SP');
+    expect(screen.getByLabelText(/CEP/i)).toHaveValue('01234-567');
+    expect(screen.getByLabelText(/País/i)).toHaveValue('Brasil');
+  });
+
+  it('deve chamar onChange ao digitar nos campos', () => {
+    render(<AddressStep onChange={mockOnChange} data={defaultData} />);
+
+    fireEvent.change(screen.getByLabelText(/Rua/i), {
+      target: { value: 'Rua Nova' },
+    });
+    expect(mockOnChange).toHaveBeenCalledWith('address', 'Rua Nova');
+
+    fireEvent.change(screen.getByLabelText(/Cidade/i), {
+      target: { value: 'Rio de Janeiro' },
+    });
+    expect(mockOnChange).toHaveBeenCalledWith('city', 'Rio de Janeiro');
+
+    fireEvent.change(screen.getByLabelText(/Número/i), {
+      target: { value: '456' },
+    });
+    expect(mockOnChange).toHaveBeenCalledWith('number', '456');
+
+    fireEvent.change(screen.getByLabelText(/Bairro/i), {
+      target: { value: 'Jardins' },
+    });
+    expect(mockOnChange).toHaveBeenCalledWith('neighborhood', 'Jardins');
+
+    fireEvent.change(screen.getByLabelText(/Estado/i), {
+      target: { value: 'RJ' },
+    });
+    expect(mockOnChange).toHaveBeenCalledWith('state', 'RJ');
+
+    fireEvent.change(screen.getByLabelText(/CEP/i), {
+      target: { value: '22222-000' },
+    });
+    expect(mockOnChange).toHaveBeenCalledWith('zipCode', '22222-000');
+
+    fireEvent.change(screen.getByLabelText(/País/i), {
+      target: { value: 'Argentina' },
+    });
+    expect(mockOnChange).toHaveBeenCalledWith('country', 'Argentina');
+  });
+});

--- a/src/features/auth/pages/signup/components/addressStep/index.tsx
+++ b/src/features/auth/pages/signup/components/addressStep/index.tsx
@@ -1,0 +1,74 @@
+import { Grid, TextField } from '@mui/material';
+import type { FormStepProps } from '../../interface';
+
+export const AddressStep = ({ onChange, data }: FormStepProps) => {
+  return (
+    <>
+      <Grid container spacing={2}>
+        <Grid size={{ xs: 6, sm: 6 }}>
+          <TextField
+            fullWidth
+            value={data.address}
+            label="Rua"
+            onChange={(e) => onChange('address', e.target.value)}
+            required
+          />
+        </Grid>
+        <Grid size={{ xs: 6, sm: 6 }}>
+          <TextField
+            fullWidth
+            value={data.number}
+            label="Número"
+            onChange={(e) => onChange('number', e.target.value)}
+            required
+          />
+        </Grid>
+        <Grid size={{ xs: 6, sm: 6 }}>
+          <TextField
+            fullWidth
+            value={data.city}
+            label="Cidade"
+            onChange={(e) => onChange('city', e.target.value)}
+            required
+          />
+        </Grid>
+        <Grid size={{ xs: 6, sm: 6 }}>
+          <TextField
+            fullWidth
+            value={data.neighborhood}
+            label="Bairro"
+            onChange={(e) => onChange('neighborhood', e.target.value)}
+            required
+          />
+        </Grid>
+        <Grid size={{ xs: 6, sm: 6 }}>
+          <TextField
+            fullWidth
+            value={data.state}
+            label="Estado"
+            onChange={(e) => onChange('state', e.target.value)}
+            required
+          />
+        </Grid>
+        <Grid size={{ xs: 6, sm: 6 }}>
+          <TextField
+            fullWidth
+            value={data.country}
+            label="País"
+            onChange={(e) => onChange('country', e.target.value)}
+            required
+          />
+        </Grid>
+        <Grid size={{ xs: 12, sm: 12 }}>
+          <TextField
+            fullWidth
+            value={data.zipCode}
+            label="CEP"
+            onChange={(e) => onChange('zipCode', e.target.value)}
+            required
+          />
+        </Grid>
+      </Grid>
+    </>
+  );
+};

--- a/src/features/auth/pages/signup/components/devInfoStep/__tests__/index.spec.tsx
+++ b/src/features/auth/pages/signup/components/devInfoStep/__tests__/index.spec.tsx
@@ -1,0 +1,89 @@
+// DevInfoStep.test.tsx
+import { render, screen, fireEvent } from '@testing-library/react';
+import { DevInfoStep } from '../';
+
+describe('DevInfoStep', () => {
+  const mockOnChange = jest.fn();
+  const defaultData = {
+    address: 'Rua das Acácias',
+    city: 'São Paulo',
+    number: '123',
+    neighborhood: 'Centro',
+    state: 'SP',
+    zipCode: '01234-567',
+    country: 'Brasil',
+    name: 'Gustavo',
+    email: 'gustavo@example.com',
+    password: '123456',
+    githubLink: 'https://github.com/gustavo',
+    linkedinLink: 'https://linkedin.com/in/gustavo',
+    bio: 'Desenvolvedor fullstack',
+    stack: ['React', 'Node.js', 'PostgreSQL'],
+    confirmPassword: '123456',
+  };
+
+  beforeEach(() => {
+    mockOnChange.mockClear();
+  });
+
+  it('deve renderizar todos os campos com labels corretos', () => {
+    render(<DevInfoStep onChange={mockOnChange} data={defaultData} />);
+
+    expect(screen.getByLabelText(/Link do Github/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Link do Linkedin/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Bio/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Stack/i)).toBeInTheDocument();
+  });
+
+  it('deve exibir os valores iniciais corretamente', () => {
+    render(<DevInfoStep onChange={mockOnChange} data={defaultData} />);
+
+    expect(screen.getByLabelText(/Link do Github/i)).toHaveValue(
+      'https://github.com/gustavo',
+    );
+    expect(screen.getByLabelText(/Link do Linkedin/i)).toHaveValue(
+      'https://linkedin.com/in/gustavo',
+    );
+    expect(screen.getByLabelText(/Bio/i)).toHaveValue(
+      'Desenvolvedor fullstack',
+    );
+    // stack vira string unida por ", "
+    expect(screen.getByLabelText(/Stack/i)).toHaveValue(
+      'React, Node.js, PostgreSQL',
+    );
+  });
+
+  it('deve chamar onChange ao digitar nos campos', () => {
+    render(<DevInfoStep onChange={mockOnChange} data={defaultData} />);
+
+    fireEvent.change(screen.getByLabelText(/Link do Github/i), {
+      target: { value: 'https://github.com/akira' },
+    });
+    expect(mockOnChange).toHaveBeenCalledWith(
+      'githubLink',
+      'https://github.com/akira',
+    );
+
+    fireEvent.change(screen.getByLabelText(/Link do Linkedin/i), {
+      target: { value: 'https://linkedin.com/in/akira' },
+    });
+    expect(mockOnChange).toHaveBeenCalledWith(
+      'linkedinLink',
+      'https://linkedin.com/in/akira',
+    );
+
+    fireEvent.change(screen.getByLabelText(/Bio/i), {
+      target: { value: 'Novo bio' },
+    });
+    expect(mockOnChange).toHaveBeenCalledWith('bio', 'Novo bio');
+
+    fireEvent.change(screen.getByLabelText(/Stack/i), {
+      target: { value: 'Angular, Java, MongoDB' },
+    });
+    expect(mockOnChange).toHaveBeenCalledWith('stack', [
+      'Angular',
+      'Java',
+      'MongoDB',
+    ]);
+  });
+});

--- a/src/features/auth/pages/signup/components/devInfoStep/index.tsx
+++ b/src/features/auth/pages/signup/components/devInfoStep/index.tsx
@@ -1,0 +1,38 @@
+import { TextField } from '@mui/material';
+import type { FormStepProps } from '../../interface';
+
+export const DevInfoStep = ({ onChange, data }: FormStepProps) => {
+  return (
+    <>
+      <TextField
+        value={data.githubLink}
+        label="Link do Github"
+        onChange={(e) => onChange('githubLink', e.target.value)}
+        required
+      />
+      <TextField
+        value={data.linkedinLink}
+        label="Link do Linkedin"
+        onChange={(e) => onChange('linkedinLink', e.target.value)}
+        required
+      />
+      <TextField
+        value={data.bio}
+        label="Bio"
+        onChange={(e) => onChange('bio', e.target.value)}
+        required
+      />
+      <TextField
+        value={data.stack.join(', ')}
+        label="Stack"
+        onChange={(e) =>
+          onChange(
+            'stack',
+            e.target.value.split(', ').map((item) => item.trim()),
+          )
+        }
+        required
+      />
+    </>
+  );
+};

--- a/src/features/auth/pages/signup/index.tsx
+++ b/src/features/auth/pages/signup/index.tsx
@@ -1,0 +1,102 @@
+import {
+  Box,
+  Button,
+  Container,
+  Stepper,
+  Step,
+  StepLabel,
+} from '@mui/material';
+import { useState } from 'react';
+import { AccountStep } from './components/accountStep';
+import { AddressStep } from './components/addressStep';
+import { DevInfoStep } from './components/devInfoStep';
+
+export const Signup = () => {
+  const steps = ['Informações Pessoais', 'Dados de Acesso', 'Confirmação'];
+  const [activeStep, setActiveStep] = useState(0);
+  const handleNext = () => setActiveStep((prev) => prev + 1);
+  const handleBack = () => setActiveStep((prev) => prev - 1);
+  const [formData, setFormData] = useState({
+    name: '',
+    email: '',
+    password: '',
+    address: '',
+    number: '',
+    complement: '',
+    neighborhood: '',
+    city: '',
+    state: '',
+    zipCode: '',
+    country: '',
+    githubLink: '',
+    linkedinLink: '',
+    bio: '',
+    stack: [],
+    confirmPassword: '',
+  });
+  const renderStepContent = (step: number) => {
+    switch (step) {
+      case 0:
+        return <AccountStep onChange={() => {}} data={formData} />;
+      case 1:
+        return (
+          <AddressStep
+            onChange={(field, value) =>
+              setFormData({ ...formData, [field]: value })
+            }
+            data={formData}
+          />
+        );
+      case 2:
+        return (
+          <DevInfoStep
+            onChange={(field, value) =>
+              setFormData({ ...formData, [field]: value })
+            }
+            data={formData}
+          />
+        );
+      default:
+        return 'Unknown step';
+    }
+  };
+
+  return (
+    <>
+      <Box component="section" sx={{ padding: 2 }}>
+        <Container maxWidth="sm">
+          <Stepper activeStep={activeStep} alternativeLabel>
+            {steps.map((label) => (
+              <Step key={label}>
+                <StepLabel>{label}</StepLabel>
+              </Step>
+            ))}
+          </Stepper>
+        </Container>
+      </Box>
+      <Box sx={{ padding: 2 }}>
+        <Container maxWidth="sm">
+          <form method="post">
+            <Box display="flex" flexDirection="column" gap={2}>
+              {renderStepContent(activeStep)}
+            </Box>
+          </form>
+          <Box display="flex" justifyContent="space-between" mt={4}>
+            <Button disabled={activeStep === 0} onClick={handleBack}>
+              Voltar
+            </Button>
+            {activeStep === steps.length - 1 ? (
+              <Button variant="contained" color="primary" onClick={() => {}}>
+                Finalizar
+              </Button>
+            ) : (
+              <Button variant="contained" onClick={handleNext}>
+                Próximo
+              </Button>
+            )}
+          </Box>
+        </Container>
+      </Box>
+    </>
+  );
+};

--- a/src/features/auth/pages/signup/interface.ts
+++ b/src/features/auth/pages/signup/interface.ts
@@ -1,0 +1,27 @@
+export type onChangeAction = (
+  field: keyof FormData,
+  value: string | Array<string>,
+) => void;
+export type FormData = {
+  name: string;
+  email: string;
+  password: string;
+  address: string;
+  number: string;
+  complement?: string;
+  neighborhood: string;
+  city: string;
+  state: string;
+  zipCode: string;
+  country: string;
+  githubLink: string;
+  linkedinLink: string;
+  bio: string;
+  stack: Array<string>;
+  confirmPassword: string;
+};
+
+export type FormStepProps = {
+  onChange: onChangeAction;
+  data: FormData;
+};

--- a/src/features/auth/route.tsx
+++ b/src/features/auth/route.tsx
@@ -1,0 +1,9 @@
+import type { RouteObject } from 'react-router-dom';
+import { Signup } from './pages/signup';
+
+export const AUTH_ROUTE: RouteObject[] = [
+  {
+    path: '/auth/signup',
+    element: <Signup />,
+  },
+];

--- a/src/shared/component/main/MainContainer.tsx
+++ b/src/shared/component/main/MainContainer.tsx
@@ -2,4 +2,8 @@ import styled from '@emotion/styled';
 
 export const MainContainer = styled.div`
   padding-top: 80px;
+  min-height: calc(100vh - 80px);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
 `;

--- a/src/shared/routes.ts
+++ b/src/shared/routes.ts
@@ -1,4 +1,5 @@
 import { createBrowserRouter } from 'react-router-dom';
 import { HOME_ROUTE } from '../features/home/route';
+import { AUTH_ROUTE } from '../features/auth/route';
 
-export const router = createBrowserRouter([...HOME_ROUTE]);
+export const router = createBrowserRouter([...HOME_ROUTE, ...AUTH_ROUTE]);


### PR DESCRIPTION
## 📌 Description
Adding the signup page and multi step form design 
<!-- Brief description of what changed -->

## 🧪 Realized Tests

- [X] Local tests
- [X] All tests passed

<!-- Add the relevant tests -->
Tests of UI of sinup page and multi step form
test of every step ui
## 📎 Changes
- Adding Signup page design
- Adding multi step form with stepper and 3 steps
- Address step
- account step 
- devInfo step

## 🧩 Issues

<!-- If it close some issue or is related to please Mark like Closes#1 or Relates#` -->

Closes #

## ⚠️ Checklist

- [X] The code is in the same pattern of the project
- [X] Update the docs (Only if needed)

## 📝 Comments

<!-- Add important notes to the revisor -->
