### PR TITLE
feat: adding auth context and provider and profile page

### DIFF
--- a/src/features/profile/components/infoContainer/__tests__/index.spec.tsx
+++ b/src/features/profile/components/infoContainer/__tests__/index.spec.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from '@testing-library/react';
+import { InfoContainer } from '..';
+
+describe('InfoContainer', () => {
+  it('should render label and value', () => {
+    render(<InfoContainer label="Name" value={<span>Gustavo</span>} />);
+
+    expect(screen.getByText('Name:')).toBeInTheDocument();
+    expect(screen.getByText('Gustavo')).toBeInTheDocument();
+  });
+
+  it('should render multiple values when passed', () => {
+    render(
+      <InfoContainer
+        label="Hobbies"
+        value={[<span key="1">Read</span>, <span key="2">Play</span>]}
+      />,
+    );
+
+    expect(screen.getByText('Read')).toBeInTheDocument();
+    expect(screen.getByText('Play')).toBeInTheDocument();
+  });
+
+  it('should use default size when custom size its not passed', () => {
+    render(<InfoContainer label="Age" value={<span>22</span>} />);
+    const grid = screen.getByText('22').closest('.MuiGrid-root');
+    expect(grid).toHaveAttribute(
+      'class',
+      expect.stringContaining('MuiGrid-root'),
+    );
+  });
+
+  it('should use custom size when its passed', () => {
+    render(
+      <InfoContainer
+        label="Weight"
+        value={<span>70kg</span>}
+        size={{ xs: 12, md: 4, lg: 3 }}
+      />,
+    );
+
+    const grid = screen.getByText('70kg').closest('.MuiGrid-root');
+    expect(grid).toBeInTheDocument();
+  });
+});

--- a/src/features/profile/components/infoContainer/index.tsx
+++ b/src/features/profile/components/infoContainer/index.tsx
@@ -1,0 +1,16 @@
+import type { JSX } from '@emotion/react/jsx-runtime';
+import { Grid, Typography } from '@mui/material';
+
+export const InfoContainer = (info: {
+  label: string;
+  value: JSX.Element[] | JSX.Element;
+  size?: { xs: number; md: number; lg: number };
+}) => {
+  const size = info.size ? info.size : { xs: 12, md: 6, lg: 6 };
+  return (
+    <Grid size={size}>
+      <Typography fontWeight={'bold'}>{info.label}:</Typography>
+      {info.value}
+    </Grid>
+  );
+};

--- a/src/features/profile/components/layout/__tests__/layout.spec.tsx
+++ b/src/features/profile/components/layout/__tests__/layout.spec.tsx
@@ -8,31 +8,13 @@ vi.mock('../../side-menu/sideMenu', () => ({
 
 describe('ProfileLayout', () => {
   it('deve renderizar o SideMenu', () => {
-    render(
-      <ProfileLayout>
-        <div>Conteúdo</div>
-      </ProfileLayout>,
-    );
+    render(<ProfileLayout />);
 
     expect(screen.getByTestId('side-menu')).toBeInTheDocument();
   });
 
-  it('deve renderizar os children corretamente', () => {
-    render(
-      <ProfileLayout>
-        <p>Texto do perfil</p>
-      </ProfileLayout>,
-    );
-
-    expect(screen.getByText('Texto do perfil')).toBeInTheDocument();
-  });
-
   it('aplica o estilo de layout corretamente', () => {
-    const { container } = render(
-      <ProfileLayout>
-        <span>Child</span>
-      </ProfileLayout>,
-    );
+    const { container } = render(<ProfileLayout />);
 
     const layoutDiv = container.firstChild as HTMLElement;
 

--- a/src/features/profile/components/layout/layout.tsx
+++ b/src/features/profile/components/layout/layout.tsx
@@ -1,10 +1,13 @@
+import { Outlet } from 'react-router-dom';
 import { SideMenu } from '../side-menu/sideMenu';
 
-export const ProfileLayout = ({ children }: { children: React.ReactNode }) => {
+export const ProfileLayout = () => {
   return (
     <div style={{ display: 'flex' }}>
       <SideMenu />
-      <div style={{ flex: 1, padding: '20px' }}>{children}</div>
+      <div style={{ flex: 1, padding: '20px' }}>
+        <Outlet />
+      </div>
     </div>
   );
 };

--- a/src/features/profile/pages/information/__tests__/index.spec.tsx
+++ b/src/features/profile/pages/information/__tests__/index.spec.tsx
@@ -1,0 +1,43 @@
+import { vi, type Mock } from 'vitest';
+import { useAuth } from '../../../../../shared/context/auth/authContext';
+import { render, screen } from '@testing-library/react';
+import { InfoPage } from '..';
+
+vi.mock('../../../../../shared/context/auth/authContext', () => ({
+  useAuth: vi.fn(),
+}));
+describe('Info Page Ui tests', () => {
+  const user = {
+    id: '',
+    name: 'Gustavo',
+    email: 'akirauekita@gmail.com',
+    bio: 'Bio test',
+    address: {
+      street: 'address',
+      city: 'city',
+      state: 'state',
+      zipCode: '08900-000',
+      country: 'BR',
+    },
+    githubLink: 'githubLink',
+    linkedinLink: 'linkedinLink',
+    stack: ['java', 'react'],
+    isActive: true,
+  };
+  beforeAll(() => {
+    (useAuth as Mock).mockReturnValue({
+      user: user,
+    });
+  });
+  it('should print the title and the user info when user is present', () => {
+    render(<InfoPage />);
+    expect(screen.getByText('Informações Pessoais')).toBeInTheDocument();
+    expect(screen.getByText('Gustavo')).toBeInTheDocument();
+    expect(screen.getByText('akirauekita@gmail.com')).toBeInTheDocument();
+    expect(screen.getByText('Bio test')).toBeInTheDocument();
+    expect(screen.getByText('githubLink')).toBeInTheDocument();
+    expect(screen.getByText('linkedinLink')).toBeInTheDocument();
+    expect(screen.getByText('java')).toBeInTheDocument();
+    expect(screen.getByText('react')).toBeInTheDocument();
+  });
+});

--- a/src/features/profile/pages/information/index.tsx
+++ b/src/features/profile/pages/information/index.tsx
@@ -1,0 +1,97 @@
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  Chip,
+  Grid,
+  Typography,
+} from '@mui/material';
+import { useAuth } from '../../../../shared/context/auth/authContext';
+import { InfoContainer } from '../../components/infoContainer';
+import { ExpandMore } from '@mui/icons-material';
+
+export const InfoPage = () => {
+  const { user } = useAuth();
+  const userInfo = user!;
+  return (
+    <Grid container spacing={2}>
+      <Grid size={{ xs: 12 }}>
+        <Accordion defaultExpanded>
+          <AccordionSummary expandIcon={<ExpandMore />}>
+            <Typography variant="h6" gutterBottom>
+              Informações Pessoais
+            </Typography>
+          </AccordionSummary>
+          <AccordionDetails>
+            <Grid container spacing={2}>
+              <InfoContainer
+                label="Nome"
+                value={<Typography>{userInfo.name}</Typography>}
+                size={{ xs: 12, lg: 4, md: 4 }}
+              />
+              <InfoContainer
+                label="Email"
+                value={<Typography>{userInfo.email}</Typography>}
+                size={{ xs: 12, lg: 4, md: 4 }}
+              />
+              <InfoContainer
+                label="Stack"
+                value={userInfo.stack.map((s) => (
+                  <Chip key={s} label={s} size="small" />
+                ))}
+                size={{ xs: 12, lg: 4, md: 4 }}
+              />
+              <InfoContainer
+                label="Github Link"
+                value={<Typography>{userInfo.githubLink}</Typography>}
+              />
+              <InfoContainer
+                label="Linkedin Link"
+                value={<Typography>{userInfo.linkedinLink}</Typography>}
+              />
+              <InfoContainer
+                label="Bio"
+                value={<Typography>{userInfo.bio}</Typography>}
+                size={{ xs: 12, lg: 12, md: 12 }}
+              />
+            </Grid>
+          </AccordionDetails>
+        </Accordion>
+      </Grid>
+
+      <Grid size={{ xs: 12 }}>
+        <Accordion>
+          <AccordionSummary expandIcon={<ExpandMore />}>
+            <Typography variant="h6" gutterBottom>
+              Endereço
+            </Typography>
+          </AccordionSummary>
+          <AccordionDetails>
+            <Grid container>
+              <InfoContainer
+                label="Rua"
+                value={<Typography>{userInfo.address.street}</Typography>}
+              />
+              <InfoContainer
+                label="Cidade"
+                value={<Typography>{userInfo.address.city}</Typography>}
+              />
+              <InfoContainer
+                label="Estado"
+                value={<Typography>{userInfo.address.state}</Typography>}
+              />
+              <InfoContainer
+                label="País"
+                value={<Typography>{userInfo.address.country}</Typography>}
+              />
+              <InfoContainer
+                label="CEP"
+                value={<Typography>{userInfo.address.zipCode}</Typography>}
+              />
+            </Grid>
+          </AccordionDetails>
+        </Accordion>
+      </Grid>
+    </Grid>
+  );
+};

--- a/src/features/profile/route.tsx
+++ b/src/features/profile/route.tsx
@@ -1,5 +1,8 @@
 import type { RouteObject } from 'react-router-dom';
 import { ProfileLayout } from './components/layout/layout';
+import { PrivateRoute } from '../../shared/component/privateRoute';
+import { InfoPage } from './pages/information';
+import { AuthProvider } from '../../shared/context/auth/authContext';
 
 export const PROFILE_PATHS = {
   PROFILE: '/profile',
@@ -8,11 +11,17 @@ export const PROFILE_PATHS = {
 export const PROFILE_ROUTE: RouteObject[] = [
   {
     path: PROFILE_PATHS.PROFILE,
-    element: <ProfileLayout children={undefined} />,
+    element: (
+      <AuthProvider>
+        <PrivateRoute>
+          <ProfileLayout />
+        </PrivateRoute>
+      </AuthProvider>
+    ),
     children: [
       {
         path: '',
-        element: <div>Profile Home</div>,
+        element: <InfoPage />,
       },
     ],
   },

--- a/src/shared/component/privateRoute/__tests__/index.spec.tsx
+++ b/src/shared/component/privateRoute/__tests__/index.spec.tsx
@@ -1,0 +1,61 @@
+import { vi, type Mock } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { useAuth } from '../../../context/auth/authContext';
+import { PrivateRoute } from '..';
+import { MemoryRouter } from 'react-router-dom';
+
+vi.mock('../../../context/auth/authContext', () => ({
+  useAuth: vi.fn(),
+}));
+
+describe('Private Route', () => {
+  const mockUseAuth = useAuth as Mock;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('when isAuthenticated is false should go to login page', () => {
+    mockUseAuth.mockReturnValue({ isAuthenticated: false, loading: false });
+
+    render(
+      <MemoryRouter>
+        <PrivateRoute>
+          <div>Conteúdo privado</div>
+        </PrivateRoute>
+      </MemoryRouter>,
+    );
+
+    expect(screen.queryByText('Conteúdo privado')).not.toBeInTheDocument();
+  });
+
+  it('when loading is true should be loading text in screen', () => {
+    mockUseAuth.mockReturnValue({ isAuthenticated: false, loading: true });
+
+    render(
+      <MemoryRouter>
+        <PrivateRoute>
+          <div>Conteúdo privado</div>
+        </PrivateRoute>
+      </MemoryRouter>,
+    );
+
+    expect(screen.queryByText('Loading...')).toBeInTheDocument();
+    expect(screen.queryByText('Conteúdo privado')).not.toBeInTheDocument();
+  });
+
+  it('when loading is false and isAuthenticated true should be showing component', () => {
+    mockUseAuth.mockReturnValue({ isAuthenticated: true, loading: false });
+
+    render(
+      <MemoryRouter>
+        <PrivateRoute>
+          <div>Conteúdo privado</div>
+        </PrivateRoute>
+      </MemoryRouter>,
+    );
+
+    expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
+    expect(screen.queryByText('Conteúdo privado')).toBeInTheDocument();
+  });
+});

--- a/src/shared/component/privateRoute/index.tsx
+++ b/src/shared/component/privateRoute/index.tsx
@@ -1,0 +1,12 @@
+import { Navigate } from 'react-router-dom';
+import { useAuth } from '../../context/auth/authContext';
+import type { JSX } from '@emotion/react/jsx-runtime';
+
+export function PrivateRoute({ children }: { children: JSX.Element }) {
+  const { isAuthenticated, loading } = useAuth();
+
+  if (loading) return <p>Loading...</p>;
+  if (!isAuthenticated) return <Navigate to="/auth/signin" replace />;
+
+  return children;
+}

--- a/src/shared/context/auth/__tests__/authContext.spec.tsx
+++ b/src/shared/context/auth/__tests__/authContext.spec.tsx
@@ -1,0 +1,83 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, type Mock } from 'vitest';
+import { AuthProvider, useAuth } from '../authContext';
+import { useUserInfo } from '../../../hooks/useUserInfo';
+import type { User } from '../../../types/user';
+
+vi.mock('../../../hooks/useUserInfo', () => ({
+  useUserInfo: vi.fn(),
+}));
+
+const Consumer = () => {
+  const { user, loading, isAuthenticated } = useAuth();
+  return (
+    <div>
+      <div data-testid="user">{user ? user.name : 'no-user'}</div>
+      <div data-testid="loading">{loading ? 'loading' : 'not-loading'}</div>
+      <div data-testid="auth">{isAuthenticated ? 'yes' : 'no'}</div>
+    </div>
+  );
+};
+
+describe('AuthProvider', () => {
+  it('should render user name and yes when authenticated ', () => {
+    (useUserInfo as Mock).mockReturnValue({
+      user: { id: '1', name: 'Gustavo' } as User,
+      loading: false,
+    });
+
+    render(
+      <AuthProvider>
+        <Consumer />
+      </AuthProvider>,
+    );
+
+    expect(screen.getByTestId('user').textContent).toBe('Gustavo');
+    expect(screen.getByTestId('loading').textContent).toBe('not-loading');
+    expect(screen.getByTestId('auth').textContent).toBe('yes');
+  });
+
+  it('should render no-user and no without user', () => {
+    (useUserInfo as Mock).mockReturnValue({
+      user: null,
+      loading: false,
+    });
+
+    render(
+      <AuthProvider>
+        <Consumer />
+      </AuthProvider>,
+    );
+
+    expect(screen.getByTestId('user').textContent).toBe('no-user');
+    expect(screen.getByTestId('loading').textContent).toBe('not-loading');
+    expect(screen.getByTestId('auth').textContent).toBe('no');
+  });
+
+  it('should render when is loading', () => {
+    (useUserInfo as Mock).mockReturnValue({
+      user: null,
+      loading: true,
+    });
+
+    render(
+      <AuthProvider>
+        <Consumer />
+      </AuthProvider>,
+    );
+
+    expect(screen.getByTestId('loading').textContent).toBe('loading');
+    expect(screen.getByTestId('auth').textContent).toBe('no');
+  });
+
+  it('should thrown error when is used outside provider', () => {
+    const Thrower = () => {
+      useAuth();
+      return null;
+    };
+
+    expect(() => render(<Thrower />)).toThrow(
+      'useAuth must be used within AuthProvider',
+    );
+  });
+});

--- a/src/shared/context/auth/authContext.tsx
+++ b/src/shared/context/auth/authContext.tsx
@@ -1,0 +1,27 @@
+import { createContext, useContext } from 'react';
+import { useUserInfo } from '../../hooks/useUserInfo';
+import type { User } from '../../types/user';
+/* eslint-disable react-refresh/only-export-components */
+interface AuthContextValue {
+  user: User | null;
+  loading: boolean;
+  isAuthenticated: boolean;
+}
+
+const AuthContext = createContext<AuthContextValue | undefined>(undefined);
+
+export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
+  const { user, loading } = useUserInfo();
+
+  return (
+    <AuthContext.Provider value={{ user, loading, isAuthenticated: !!user }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};
+
+export const useAuth = () => {
+  const ctx = useContext(AuthContext);
+  if (!ctx) throw new Error('useAuth must be used within AuthProvider');
+  return ctx;
+};

--- a/src/shared/hooks/__tests__/useUserInfo.spec.ts
+++ b/src/shared/hooks/__tests__/useUserInfo.spec.ts
@@ -1,0 +1,53 @@
+import { vi, type Mock } from 'vitest';
+import { api } from '../../infra/api';
+import { renderHook, waitFor } from '@testing-library/react';
+import { useUserInfo } from '../useUserInfo';
+
+vi.mock('../../infra/api', () => ({
+  api: {
+    get: vi.fn(),
+  },
+}));
+describe('useUserInfo', () => {
+  const mockGet = api.get as Mock;
+  it('when request is successfull return user and isAuthenticated true', async () => {
+    mockGet.mockResolvedValueOnce({
+      data: {
+        id: '',
+        name: '',
+        email: '',
+        bio: '',
+        address: {
+          street: '',
+          city: '',
+          state: '',
+          zipCode: '',
+          country: '',
+        },
+        githubLink: '',
+        linkedinLink: '',
+        stack: [],
+        isActive: true,
+      },
+    });
+    const { result } = renderHook(() => useUserInfo());
+    expect(result.current.loading).toBe(true);
+    expect(result.current.user).toBe(null);
+    await waitFor(() => {
+      expect(result.current.user).not.toBe(null);
+      expect(result.current.loading).toBe(false);
+      expect(result.current.isAuthenticated).toBe(true);
+    });
+  });
+  it('when request fail return user null and isAuthenticated false', async () => {
+    mockGet.mockRejectedValueOnce(Error(''));
+    const { result } = renderHook(() => useUserInfo());
+    expect(result.current.loading).toBe(true);
+    expect(result.current.user).toBe(null);
+    await waitFor(() => {
+      expect(result.current.user).toBe(null);
+      expect(result.current.loading).toBe(false);
+      expect(result.current.isAuthenticated).toBe(false);
+    });
+  });
+});

--- a/src/shared/hooks/useUserInfo.ts
+++ b/src/shared/hooks/useUserInfo.ts
@@ -1,0 +1,21 @@
+import { useEffect, useState } from 'react';
+import { api } from '../infra/api';
+import type { User } from '../types/user';
+
+export function useUserInfo() {
+  const [user, setUser] = useState<User | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    api
+      .get<User>('/v1/dev-profiles/profile')
+      .then((res) => setUser(res.data))
+      .catch((err) => {
+        console.log(err);
+        setUser(null);
+      })
+      .finally(() => setLoading(false));
+  }, []);
+
+  return { user, loading, isAuthenticated: !!user };
+}

--- a/src/shared/types/user.ts
+++ b/src/shared/types/user.ts
@@ -1,0 +1,19 @@
+export type User = {
+  id: string;
+  name: string;
+  email: string;
+  bio: string;
+  address: Address;
+  githubLink: string;
+  linkedinLink: string;
+  stack: string[];
+  isActive: boolean;
+};
+
+export type Address = {
+  street: string;
+  city: string;
+  state: string;
+  zipCode: string;
+  country: string;
+};


### PR DESCRIPTION
## 📌 Description
Adding auth context ,provider and hook to know if a user is logged and it information. Private route to make secure routes. And profile page 
<!-- Brief description of what changed -->

## 🧪 Realized Tests

- [X] Local tests
- [X] All tests passed

<!-- Add the relevant tests -->
- Tests of provider, context and hook of auth
- Tests of private route
- Profile page ui tests
## 📎 Changes
- Adding auth context and provider
- useAuth and useUserInfo to know if user is logged and get user info
- Profile page UI and using user info
## 🧩 Issues

<!-- If it close some issue or is related to please Mark like Closes#1 or Relates#` -->

Closes #

## ⚠️ Checklist

- [X] The code is in the same pattern of the project
- [X] Update the docs (Only if needed)

## 📝 Comments

<!-- Add important notes to the revisor -->
