### PR TITLE
feat: adding button edit profile on information page

### DIFF
--- a/src/features/profile/pages/information/__tests__/index.spec.tsx
+++ b/src/features/profile/pages/information/__tests__/index.spec.tsx
@@ -3,13 +3,16 @@ import { useAuth } from '../../../../../shared/context/auth/authContext';
 import { render, screen } from '@testing-library/react';
 import { InfoPage } from '..';
 
-vi.mock('../../../../../shared/context/auth/authContext', async(importOriginal) => ({
-  ...await importOriginal(),
-  useAuth: vi.fn(),
-}));
+vi.mock(
+  '../../../../../shared/context/auth/authContext',
+  async (importOriginal) => ({
+    ...(await importOriginal()),
+    useAuth: vi.fn(),
+  }),
+);
 
-vi.mock('react-router-dom', async(importOriginal) => ({
-  ...await importOriginal(),
+vi.mock('react-router-dom', async (importOriginal) => ({
+  ...(await importOriginal()),
   useNavigate: () => vi.fn(),
 }));
 describe('Info Page Ui tests', () => {

--- a/src/features/profile/pages/information/__tests__/index.spec.tsx
+++ b/src/features/profile/pages/information/__tests__/index.spec.tsx
@@ -3,8 +3,14 @@ import { useAuth } from '../../../../../shared/context/auth/authContext';
 import { render, screen } from '@testing-library/react';
 import { InfoPage } from '..';
 
-vi.mock('../../../../../shared/context/auth/authContext', () => ({
+vi.mock('../../../../../shared/context/auth/authContext', async(importOriginal) => ({
+  ...await importOriginal(),
   useAuth: vi.fn(),
+}));
+
+vi.mock('react-router-dom', async(importOriginal) => ({
+  ...await importOriginal(),
+  useNavigate: () => vi.fn(),
 }));
 describe('Info Page Ui tests', () => {
   const user = {

--- a/src/features/profile/pages/information/index.tsx
+++ b/src/features/profile/pages/information/index.tsx
@@ -19,7 +19,11 @@ export const InfoPage = () => {
   const navigate = useNavigate();
   return (
     <Grid container spacing={2}>
-      <Button variant="contained" color="primary" onClick={()=>navigate(PROFILE_PATHS.PROFILE_EDIT)}>
+      <Button
+        variant="contained"
+        color="primary"
+        onClick={() => navigate(PROFILE_PATHS.PROFILE_EDIT)}
+      >
         Editar Informações
       </Button>
       <Grid size={{ xs: 12 }}>

--- a/src/features/profile/pages/information/index.tsx
+++ b/src/features/profile/pages/information/index.tsx
@@ -2,6 +2,7 @@ import {
   Accordion,
   AccordionDetails,
   AccordionSummary,
+  Button,
   Chip,
   Grid,
   Typography,
@@ -9,12 +10,18 @@ import {
 import { useAuth } from '../../../../shared/context/auth/authContext';
 import { InfoContainer } from '../../components/infoContainer';
 import { ExpandMore } from '@mui/icons-material';
+import { PROFILE_PATHS } from '../../route';
+import { useNavigate } from 'react-router-dom';
 
 export const InfoPage = () => {
   const { user } = useAuth();
   const userInfo = user!;
+  const navigate = useNavigate();
   return (
     <Grid container spacing={2}>
+      <Button variant="contained" color="primary" onClick={()=>navigate(PROFILE_PATHS.PROFILE_EDIT)}>
+        Editar Informações
+      </Button>
       <Grid size={{ xs: 12 }}>
         <Accordion defaultExpanded>
           <AccordionSummary expandIcon={<ExpandMore />}>

--- a/src/features/profile/route.tsx
+++ b/src/features/profile/route.tsx
@@ -7,6 +7,7 @@ import { EditProfilePage } from './pages/profile-edit';
 
 export const PROFILE_PATHS = {
   PROFILE: '/profile',
+  PROFILE_EDIT: '/profile/edit',
 };
 
 export const PROFILE_ROUTE: RouteObject[] = [


### PR DESCRIPTION
## 📌 Description
Adding button edit profile on information profile page to go to edit page
<!-- Brief description of what changed -->

## 🧪 Realized Tests

- [X] Local tests
- [X] All tests passed

<!-- Add the relevant tests -->

## 📎 Changes
- Adding button edit profile on information profile page to go to edit page
## 🧩 Issues

<!-- If it close some issue or is related to please Mark like Closes#1 or Relates#` -->

Closes #

## ⚠️ Checklist

- [X] The code is in the same pattern of the project
- [X] Update the docs (Only if needed)

## 📝 Comments

<!-- Add important notes to the revisor -->
