### PR TITLE
feat: adding project modal and tests

### DIFF
--- a/src/features/profile/pages/projects/components/project-modal/__tests__/projectModal.spec.tsx
+++ b/src/features/profile/pages/projects/components/project-modal/__tests__/projectModal.spec.tsx
@@ -1,24 +1,29 @@
-import { render, screen, fireEvent } from "@testing-library/react";
-import { ProjectModal } from "../projectModal";
-import type { Project, CreateProjectDTO } from "../../../../../../../shared/infra/services/projects/interface";
-import { vi } from "vitest";
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ProjectModal } from '../projectModal';
+import type {
+  Project,
+  CreateProjectDTO,
+} from '../../../../../../../shared/infra/services/projects/interface';
+import { vi } from 'vitest';
 
-describe("ProjectModal", () => {
+describe('ProjectModal', () => {
   const baseProject: Project = {
-    id: "1",
-    name: "Test Project",
-    description: "Some description",
-    repoUrl: "https://github.com/example/repo",
-    owner:{
-        id: "dev-123",
-        name: "Dev Name",
-    }
+    id: '1',
+    name: 'Test Project',
+    description: 'Some description',
+    repoUrl: 'https://github.com/example/repo',
+    owner: {
+      id: 'dev-123',
+      name: 'Dev Name',
+    },
   };
 
-  const setup = (props?: Partial<React.ComponentProps<typeof ProjectModal>>) => {
+  const setup = (
+    props?: Partial<React.ComponentProps<typeof ProjectModal>>,
+  ) => {
     const defaultProps = {
       open: true,
-      devProfileId: "dev-123",
+      devProfileId: 'dev-123',
       onSubmit: vi.fn(),
       onClose: vi.fn(),
       data: null as Project | null,
@@ -26,55 +31,65 @@ describe("ProjectModal", () => {
     return render(<ProjectModal {...defaultProps} {...props} />);
   };
 
-  it("renders Add Project title when no data", () => {
+  it('renders Add Project title when no data', () => {
     setup();
-    expect(screen.getByText("Add Project")).toBeInTheDocument();
+    expect(screen.getByText('Add Project')).toBeInTheDocument();
   });
 
-  it("renders Edit Project title when data is provided", () => {
+  it('renders Edit Project title when data is provided', () => {
     setup({ data: baseProject });
-    expect(screen.getByText("Edit Project")).toBeInTheDocument();
+    expect(screen.getByText('Edit Project')).toBeInTheDocument();
   });
 
-  it("prefills fields when editing", () => {
+  it('prefills fields when editing', () => {
     setup({ data: baseProject });
-    expect(screen.getByLabelText("Project Name")).toHaveValue("Test Project");
-    expect(screen.getByLabelText("Repository URL")).toHaveValue("https://github.com/example/repo");
-    expect(screen.getByLabelText("Description")).toHaveValue("Some description");
+    expect(screen.getByLabelText('Project Name')).toHaveValue('Test Project');
+    expect(screen.getByLabelText('Repository URL')).toHaveValue(
+      'https://github.com/example/repo',
+    );
+    expect(screen.getByLabelText('Description')).toHaveValue(
+      'Some description',
+    );
   });
 
-  it("updates state when typing", () => {
+  it('updates state when typing', () => {
     setup();
-    const nameInput = screen.getByLabelText("Project Name") as HTMLInputElement;
-    fireEvent.change(nameInput, { target: { value: "New Project" } });
-    expect(nameInput.value).toBe("New Project");
+    const nameInput = screen.getByLabelText('Project Name') as HTMLInputElement;
+    fireEvent.change(nameInput, { target: { value: 'New Project' } });
+    expect(nameInput.value).toBe('New Project');
   });
 
-  it("calls onSubmit with correct data", () => {
+  it('calls onSubmit with correct data', () => {
     const onSubmit = vi.fn();
     setup({ onSubmit });
 
-    fireEvent.change(screen.getByLabelText("Project Name"), { target: { value: "New Project" } });
-    fireEvent.change(screen.getByLabelText("Repository URL"), { target: { value: "https://github.com/new/repo" } });
-    fireEvent.change(screen.getByLabelText("Description"), { target: { value: "Awesome description" } });
+    fireEvent.change(screen.getByLabelText('Project Name'), {
+      target: { value: 'New Project' },
+    });
+    fireEvent.change(screen.getByLabelText('Repository URL'), {
+      target: { value: 'https://github.com/new/repo' },
+    });
+    fireEvent.change(screen.getByLabelText('Description'), {
+      target: { value: 'Awesome description' },
+    });
 
-    fireEvent.click(screen.getByText("Submit"));
+    fireEvent.click(screen.getByText('Submit'));
 
     expect(onSubmit).toHaveBeenCalledTimes(1);
     const submitted: CreateProjectDTO = onSubmit.mock.calls[0][0];
     expect(submitted).toEqual({
-      name: "New Project",
-      repoUrl: "https://github.com/new/repo",
-      description: "Awesome description",
-      devProfileId: "dev-123",
+      name: 'New Project',
+      repoUrl: 'https://github.com/new/repo',
+      description: 'Awesome description',
+      devProfileId: 'dev-123',
     });
   });
 
-  it("calls onClose when Cancel is clicked", () => {
+  it('calls onClose when Cancel is clicked', () => {
     const onClose = vi.fn();
     setup({ onClose });
 
-    fireEvent.click(screen.getByText("Cancel"));
+    fireEvent.click(screen.getByText('Cancel'));
 
     expect(onClose).toHaveBeenCalledTimes(1);
   });

--- a/src/features/profile/pages/projects/components/project-modal/__tests__/projectModal.spec.tsx
+++ b/src/features/profile/pages/projects/components/project-modal/__tests__/projectModal.spec.tsx
@@ -1,0 +1,81 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ProjectModal } from "../projectModal";
+import type { Project, CreateProjectDTO } from "../../../../../../../shared/infra/services/projects/interface";
+import { vi } from "vitest";
+
+describe("ProjectModal", () => {
+  const baseProject: Project = {
+    id: "1",
+    name: "Test Project",
+    description: "Some description",
+    repoUrl: "https://github.com/example/repo",
+    owner:{
+        id: "dev-123",
+        name: "Dev Name",
+    }
+  };
+
+  const setup = (props?: Partial<React.ComponentProps<typeof ProjectModal>>) => {
+    const defaultProps = {
+      open: true,
+      devProfileId: "dev-123",
+      onSubmit: vi.fn(),
+      onClose: vi.fn(),
+      data: null as Project | null,
+    };
+    return render(<ProjectModal {...defaultProps} {...props} />);
+  };
+
+  it("renders Add Project title when no data", () => {
+    setup();
+    expect(screen.getByText("Add Project")).toBeInTheDocument();
+  });
+
+  it("renders Edit Project title when data is provided", () => {
+    setup({ data: baseProject });
+    expect(screen.getByText("Edit Project")).toBeInTheDocument();
+  });
+
+  it("prefills fields when editing", () => {
+    setup({ data: baseProject });
+    expect(screen.getByLabelText("Project Name")).toHaveValue("Test Project");
+    expect(screen.getByLabelText("Repository URL")).toHaveValue("https://github.com/example/repo");
+    expect(screen.getByLabelText("Description")).toHaveValue("Some description");
+  });
+
+  it("updates state when typing", () => {
+    setup();
+    const nameInput = screen.getByLabelText("Project Name") as HTMLInputElement;
+    fireEvent.change(nameInput, { target: { value: "New Project" } });
+    expect(nameInput.value).toBe("New Project");
+  });
+
+  it("calls onSubmit with correct data", () => {
+    const onSubmit = vi.fn();
+    setup({ onSubmit });
+
+    fireEvent.change(screen.getByLabelText("Project Name"), { target: { value: "New Project" } });
+    fireEvent.change(screen.getByLabelText("Repository URL"), { target: { value: "https://github.com/new/repo" } });
+    fireEvent.change(screen.getByLabelText("Description"), { target: { value: "Awesome description" } });
+
+    fireEvent.click(screen.getByText("Submit"));
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    const submitted: CreateProjectDTO = onSubmit.mock.calls[0][0];
+    expect(submitted).toEqual({
+      name: "New Project",
+      repoUrl: "https://github.com/new/repo",
+      description: "Awesome description",
+      devProfileId: "dev-123",
+    });
+  });
+
+  it("calls onClose when Cancel is clicked", () => {
+    const onClose = vi.fn();
+    setup({ onClose });
+
+    fireEvent.click(screen.getByText("Cancel"));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/features/profile/pages/projects/components/project-modal/projectModal.tsx
+++ b/src/features/profile/pages/projects/components/project-modal/projectModal.tsx
@@ -1,35 +1,76 @@
-import { Button, Dialog, DialogActions, DialogContent, DialogTitle, Grid, TextField, Typography } from "@mui/material"
-import type { CreateProjectDTO, Project } from "../../../../../../shared/infra/services/projects/interface"
-import { useState } from "react";
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Grid,
+  TextField,
+} from '@mui/material';
+import type {
+  CreateProjectDTO,
+  Project,
+} from '../../../../../../shared/infra/services/projects/interface';
+import { useState } from 'react';
 
-export const ProjectModal = ({open,onClose,onSubmit,data,devProfileId}:{open: boolean,onSubmit:(data: CreateProjectDTO)=>void,devProfileId: string,onClose:()=>void,data:Project|null}) => {
-    const [info,setInfo] = useState<CreateProjectDTO>(
-        {
-            name: data? data.name : "",
-            description: data? data.description : "",
-            repoUrl: data? data.repoUrl : "",
-            devProfileId
-        });
-    return (
-        <Dialog open={open} onClose={onClose}>
-            <DialogTitle>{data? "Edit Project":"Add Project"}</DialogTitle>
-            <DialogContent>
-                <Grid container spacing={1}>
-                    <Grid size={{xs:12,sm:12,md:6,lg:6}}>
-                        <TextField label="Project Name" value={info.name} fullWidth onChange={e=>setInfo({...info, name:e.target.value})}/>
-                    </Grid>
-                    <Grid size={{xs:12,sm:12,md:6,lg:6}}>
-                        <TextField label="Repository URL" value={info.repoUrl} fullWidth onChange={e=>setInfo({...info, repoUrl:e.target.value})}/>
-                    </Grid> 
-                    <Grid size={12}>
-                        <TextField label="Description" value={info.description} fullWidth multiline rows={4} onChange={e=>setInfo({...info, description:e.target.value})}/>
-                    </Grid>
-                </Grid>
-            </DialogContent>
-            <DialogActions>
-                <Button onClick={()=>onSubmit(info)}>Submit</Button>
-                <Button onClick={onClose}>Cancel</Button>
-            </DialogActions>
-        </Dialog>
-    )
-}
+export const ProjectModal = ({
+  open,
+  onClose,
+  onSubmit,
+  data,
+  devProfileId,
+}: {
+  open: boolean;
+  onSubmit: (data: CreateProjectDTO) => void;
+  devProfileId: string;
+  onClose: () => void;
+  data: Project | null;
+}) => {
+  const [info, setInfo] = useState<CreateProjectDTO>({
+    name: data ? data.name : '',
+    description: data ? data.description : '',
+    repoUrl: data ? data.repoUrl : '',
+    devProfileId,
+  });
+  return (
+    <Dialog open={open} onClose={onClose}>
+      <DialogTitle>{data ? 'Edit Project' : 'Add Project'}</DialogTitle>
+      <DialogContent>
+        <Grid container spacing={1}>
+          <Grid size={{ xs: 12, sm: 12, md: 6, lg: 6 }}>
+            <TextField
+              label="Project Name"
+              value={info.name}
+              fullWidth
+              onChange={(e) => setInfo({ ...info, name: e.target.value })}
+            />
+          </Grid>
+          <Grid size={{ xs: 12, sm: 12, md: 6, lg: 6 }}>
+            <TextField
+              label="Repository URL"
+              value={info.repoUrl}
+              fullWidth
+              onChange={(e) => setInfo({ ...info, repoUrl: e.target.value })}
+            />
+          </Grid>
+          <Grid size={12}>
+            <TextField
+              label="Description"
+              value={info.description}
+              fullWidth
+              multiline
+              rows={4}
+              onChange={(e) =>
+                setInfo({ ...info, description: e.target.value })
+              }
+            />
+          </Grid>
+        </Grid>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={() => onSubmit(info)}>Submit</Button>
+        <Button onClick={onClose}>Cancel</Button>
+      </DialogActions>
+    </Dialog>
+  );
+};

--- a/src/features/profile/pages/projects/components/project-modal/projectModal.tsx
+++ b/src/features/profile/pages/projects/components/project-modal/projectModal.tsx
@@ -1,0 +1,35 @@
+import { Button, Dialog, DialogActions, DialogContent, DialogTitle, Grid, TextField, Typography } from "@mui/material"
+import type { CreateProjectDTO, Project } from "../../../../../../shared/infra/services/projects/interface"
+import { useState } from "react";
+
+export const ProjectModal = ({open,onClose,onSubmit,data,devProfileId}:{open: boolean,onSubmit:(data: CreateProjectDTO)=>void,devProfileId: string,onClose:()=>void,data:Project|null}) => {
+    const [info,setInfo] = useState<CreateProjectDTO>(
+        {
+            name: data? data.name : "",
+            description: data? data.description : "",
+            repoUrl: data? data.repoUrl : "",
+            devProfileId
+        });
+    return (
+        <Dialog open={open} onClose={onClose}>
+            <DialogTitle>{data? "Edit Project":"Add Project"}</DialogTitle>
+            <DialogContent>
+                <Grid container spacing={1}>
+                    <Grid size={{xs:12,sm:12,md:6,lg:6}}>
+                        <TextField label="Project Name" value={info.name} fullWidth onChange={e=>setInfo({...info, name:e.target.value})}/>
+                    </Grid>
+                    <Grid size={{xs:12,sm:12,md:6,lg:6}}>
+                        <TextField label="Repository URL" value={info.repoUrl} fullWidth onChange={e=>setInfo({...info, repoUrl:e.target.value})}/>
+                    </Grid> 
+                    <Grid size={12}>
+                        <TextField label="Description" value={info.description} fullWidth multiline rows={4} onChange={e=>setInfo({...info, description:e.target.value})}/>
+                    </Grid>
+                </Grid>
+            </DialogContent>
+            <DialogActions>
+                <Button onClick={()=>onSubmit(info)}>Submit</Button>
+                <Button onClick={onClose}>Cancel</Button>
+            </DialogActions>
+        </Dialog>
+    )
+}

--- a/src/features/profile/pages/projects/hooks/useProjectsPage.ts
+++ b/src/features/profile/pages/projects/hooks/useProjectsPage.ts
@@ -11,7 +11,8 @@ export const useProjectsPage = () => {
   const [size, setSize] = useState<number>(5);
   const [totalElements, setTotalElements] = useState<number>(0);
   const devProfileId = useAuth().user!.id;
-
+  const [openModal, setOpenModal] = useState<boolean>(false);
+  const [editProject, setEditProject] = useState<Project | null>(null);
   useEffect(() => {
     setLoading(true);
     getProjectsByDevProfileId(devProfileId, page, 5)
@@ -44,10 +45,15 @@ export const useProjectsPage = () => {
       page,
       size,
       totalElements,
+      devProfileId,
+      openModal,
+      editProject
     },
     actions: {
       handlePageChange,
       handleSizeChange,
+      setOpenModal,
+      setEditProject
     },
   };
 };

--- a/src/features/profile/pages/projects/hooks/useProjectsPage.ts
+++ b/src/features/profile/pages/projects/hooks/useProjectsPage.ts
@@ -47,13 +47,13 @@ export const useProjectsPage = () => {
       totalElements,
       devProfileId,
       openModal,
-      editProject
+      editProject,
     },
     actions: {
       handlePageChange,
       handleSizeChange,
       setOpenModal,
-      setEditProject
+      setEditProject,
     },
   };
 };

--- a/src/features/profile/pages/projects/index.tsx
+++ b/src/features/profile/pages/projects/index.tsx
@@ -9,6 +9,8 @@ import {
 import { Delete, Edit, GitHub } from '@mui/icons-material';
 import { DataGrid, type GridColDef } from '@mui/x-data-grid';
 import { useProjectsPage } from './hooks/useProjectsPage';
+import { ProjectModal } from './components/project-modal/projectModal';
+import type { CreateProjectDTO } from '../../../../shared/infra/services/projects/interface';
 
 export const ProjectsPage = () => {
   const { state, actions } = useProjectsPage();
@@ -52,7 +54,7 @@ export const ProjectsPage = () => {
           </Typography>
         </Grid>
         <Grid size={2}>
-          <Button variant="outlined" color="primary">
+          <Button variant="outlined" color="primary" onClick={()=>actions.setOpenModal(true)}>
             Add New Project
           </Button>
         </Grid>
@@ -75,6 +77,7 @@ export const ProjectsPage = () => {
         }}
         loading={state.loading}
       />
+      <ProjectModal open={state.openModal} onClose={()=>{actions.setOpenModal(false)}} onSubmit={(data: CreateProjectDTO)=>console.log(data)} devProfileId={state.devProfileId} data={state.editProject}/>
     </Container>
   );
 };

--- a/src/features/profile/pages/projects/index.tsx
+++ b/src/features/profile/pages/projects/index.tsx
@@ -54,7 +54,11 @@ export const ProjectsPage = () => {
           </Typography>
         </Grid>
         <Grid size={2}>
-          <Button variant="outlined" color="primary" onClick={()=>actions.setOpenModal(true)}>
+          <Button
+            variant="outlined"
+            color="primary"
+            onClick={() => actions.setOpenModal(true)}
+          >
             Add New Project
           </Button>
         </Grid>
@@ -77,7 +81,15 @@ export const ProjectsPage = () => {
         }}
         loading={state.loading}
       />
-      <ProjectModal open={state.openModal} onClose={()=>{actions.setOpenModal(false)}} onSubmit={(data: CreateProjectDTO)=>console.log(data)} devProfileId={state.devProfileId} data={state.editProject}/>
+      <ProjectModal
+        open={state.openModal}
+        onClose={() => {
+          actions.setOpenModal(false);
+        }}
+        onSubmit={(data: CreateProjectDTO) => console.log(data)}
+        devProfileId={state.devProfileId}
+        data={state.editProject}
+      />
     </Container>
   );
 };

--- a/src/shared/infra/services/projects/interface.ts
+++ b/src/shared/infra/services/projects/interface.ts
@@ -18,3 +18,7 @@ export interface ProjectResponse {
   totalElements: number;
   totalPages: number;
 }
+
+export type CreateProjectDTO = Omit<Project, "owner"| "id"> & {
+  devProfileId: string;
+};

--- a/src/shared/infra/services/projects/interface.ts
+++ b/src/shared/infra/services/projects/interface.ts
@@ -19,6 +19,6 @@ export interface ProjectResponse {
   totalPages: number;
 }
 
-export type CreateProjectDTO = Omit<Project, "owner"| "id"> & {
+export type CreateProjectDTO = Omit<Project, 'owner' | 'id'> & {
   devProfileId: string;
 };


### PR DESCRIPTION
## 📌 Description
Adding project modal to add and edit projects from project management page
<!-- Brief description of what changed -->

## 🧪 Realized Tests

- [X] Local tests
- [X] All tests passed
Tests of ui like open, close, calling the callback function on project modal
<!-- Add the relevant tests -->

## 📎 Changes
Adding project modal on project management page, with states to open, close and pass the project to edit.
## 🧩 Issues

<!-- If it close some issue or is related to please Mark like Closes#1 or Relates#` -->

Closes #

## ⚠️ Checklist

- [X] The code is in the same pattern of the project
- [X] Update the docs (Only if needed)

## 📝 Comments

<!-- Add important notes to the revisor -->
