### PR TITLE
refactor: change feedback to uset to the projects standard on recommendation page

### DIFF
--- a/src/features/relation/pages/friend/__test__/index.spec.tsx
+++ b/src/features/relation/pages/friend/__test__/index.spec.tsx
@@ -24,6 +24,17 @@ vi.mock(
   }),
 );
 
+vi.mock(
+  '../../../../../shared/context/notification/notificationContext',
+  () => {
+    return {
+      useNotification: () => ({
+        showNotification: vi.fn(),
+      }),
+    };
+  },
+);
+
 describe('Friends Page Ui tests', () => {
   beforeAll(() => {
     (useAuth as Mock).mockReturnValue({

--- a/src/features/relation/pages/friend/hooks/__tests__/userFriendsPage.spec.ts
+++ b/src/features/relation/pages/friend/hooks/__tests__/userFriendsPage.spec.ts
@@ -17,6 +17,18 @@ vi.mock(
   }),
 );
 
+const mockShowNotification = vi.fn();
+vi.mock(
+  '../../../../../../shared/context/notification/notificationContext',
+  () => {
+    return {
+      useNotification: () => ({
+        showNotification: mockShowNotification,
+      }),
+    };
+  },
+);
+
 vi.mock(
   '../../../../../../shared/infra/services/relation/relationService',
   () => ({
@@ -67,10 +79,13 @@ describe('useFriendsPage', () => {
 
     await waitFor(() => {
       expect(errorSpy).toHaveBeenCalled();
-      expect(result.current.state.error).toBe('Erro ao pegar recomendações');
     });
 
     expect(result.current.state.recommendations.length).toBe(0);
+    expect(mockShowNotification).toHaveBeenCalledWith(
+      'Erro ao pegar recomendações',
+      'error',
+    );
   });
 
   it('should refetch when user changes', async () => {
@@ -129,7 +144,6 @@ describe('useFriendsPage', () => {
       expect(requestFriendShip).toHaveBeenCalledWith(13, 12);
       expect(result.current.state.recommendations.length).toBe(1);
       expect(result.current.state.recommendations[0].ID).toBe(34);
-      expect(result.current.state.error).toBe('');
       expect(result.current.state.loading).toBe(false);
     });
   });
@@ -155,8 +169,11 @@ describe('useFriendsPage', () => {
     await waitFor(() => {
       expect(requestFriendShip).toHaveBeenCalledWith(13, 55);
       expect(errorSpy).toHaveBeenCalled();
-      expect(result.current.state.error).toBe('Erro ao enviar solicitação');
       expect(result.current.state.recommendations.length).toBe(1);
+      expect(mockShowNotification).toHaveBeenCalledWith(
+        'Erro ao enviar solicitação de amizade',
+        'error',
+      );
     });
   });
 
@@ -181,7 +198,6 @@ describe('useFriendsPage', () => {
       expect(blockUser).toHaveBeenCalledWith(13, 12);
       expect(result.current.state.recommendations.length).toBe(1);
       expect(result.current.state.recommendations[0].ID).toBe(34);
-      expect(result.current.state.error).toBe('');
       expect(result.current.state.loading).toBe(false);
     });
   });
@@ -205,8 +221,11 @@ describe('useFriendsPage', () => {
     await waitFor(() => {
       expect(blockUser).toHaveBeenCalledWith(13, 55);
       expect(errorSpy).toHaveBeenCalled();
-      expect(result.current.state.error).toBe('Erro ao blockear usuario');
       expect(result.current.state.recommendations.length).toBe(1);
+      expect(mockShowNotification).toHaveBeenCalledWith(
+        'Erro ao bloquear usuário',
+        'error',
+      );
     });
   });
 });

--- a/src/features/relation/pages/friend/hooks/useFriendsPage.ts
+++ b/src/features/relation/pages/friend/hooks/useFriendsPage.ts
@@ -6,15 +6,15 @@ import {
   getRecommendationsByProfile,
   requestFriendShip,
 } from '../../../../../shared/infra/services/relation/relationService';
+import { useNotification } from '../../../../../shared/context/notification/notificationContext';
 
 export const useFriendsPage = () => {
   const { user } = useAuth();
+  const { showNotification } = useNotification();
   const [recommendations, setRecommendations] = useState<Recommendations[]>([]);
   const [loading, setLoading] = useState<boolean>(true);
-  const [error, setError] = useState<string>('');
   const fetchRecommendations = useCallback(async () => {
     const userId = Number.parseInt(user!.id);
-    setError('');
     setLoading(true);
     getRecommendationsByProfile(userId)
       .then((data) => {
@@ -23,12 +23,12 @@ export const useFriendsPage = () => {
       })
       .catch((error) => {
         console.error(error);
-        setError('Erro ao pegar recomendações');
+        showNotification('Erro ao pegar recomendações', 'error');
       })
       .finally(() => {
         setLoading(false);
       });
-  }, [user]);
+  }, [user, showNotification]);
   useEffect(() => {
     fetchRecommendations();
   }, [fetchRecommendations]);
@@ -44,16 +44,17 @@ export const useFriendsPage = () => {
               (recommendation) => recommendation.ID != toId,
             ),
           );
+          showNotification('Solicitação de amizade enviada', 'success');
         })
         .catch((err) => {
           console.error(err);
-          setError('Erro ao enviar solicitação');
+          showNotification('Erro ao enviar solicitação de amizade', 'error');
         })
         .finally(() => {
           setLoading(false);
         });
     },
-    [user, recommendations],
+    [user, recommendations, showNotification],
   );
 
   const blockUserAction = useCallback(
@@ -67,23 +68,23 @@ export const useFriendsPage = () => {
               (recommendation) => recommendation.ID != toId,
             ),
           );
+          showNotification('Usuário blockeado com sucesso', 'success');
         })
         .catch((err) => {
           console.error(err);
-          setError('Erro ao blockear usuario');
+          showNotification('Erro ao bloquear usuário', 'error');
         })
         .finally(() => {
           setLoading(false);
         });
     },
-    [user, recommendations],
+    [user, recommendations, showNotification],
   );
 
   return {
     state: {
       recommendations,
       loading,
-      error,
     },
     actions: {
       fetchRecommendations,

--- a/src/features/relation/pages/friend/index.tsx
+++ b/src/features/relation/pages/friend/index.tsx
@@ -1,20 +1,12 @@
-import {
-  Container,
-  Grid,
-  Skeleton,
-  Typography,
-  Box,
-  Snackbar,
-  Alert,
-} from '@mui/material';
+import { Container, Grid, Skeleton, Typography, Box } from '@mui/material';
 import { useFriendsPage } from './hooks/useFriendsPage';
 import { ProfileCard } from '../../components/profile-card/profileCard';
 
 export const FriendsPage = () => {
   const { state, actions } = useFriendsPage();
 
-  const { loading, error, recommendations } = state;
-  const { fetchRecommendations, addFriendShip, blockUserAction } = actions;
+  const { loading, recommendations } = state;
+  const { addFriendShip, blockUserAction } = actions;
   return (
     <Container sx={{ py: 4 }}>
       <Typography variant="h5" sx={{ mb: 3, fontWeight: 600 }}>
@@ -42,14 +34,6 @@ export const FriendsPage = () => {
         <Typography variant="body1" sx={{ mt: 4 }} color="text.secondary">
           Nenhuma recomendação encontrada no momento.
         </Typography>
-      )}
-
-      {error && (
-        <Snackbar color="error" open={true} onClose={fetchRecommendations}>
-          <Alert severity="error" onClose={fetchRecommendations}>
-            {error}
-          </Alert>
-        </Snackbar>
       )}
 
       {!loading && recommendations.length > 0 && (


### PR DESCRIPTION
## 📌 Description
Change feedback on ther recommendation page to the standard of the project (notification context)
<!-- Brief description of what changed -->

## 🧪 Realized Tests

- [X] Local tests
- [X] All tests passed

<!-- Add the relevant tests -->

## 📎 Changes
Change feedback on ther recommendation page to the standard of the project (notification context)

## 🧩 Issues

<!-- If it close some issue or is related to please Mark like Closes#1 or Relates#` -->

Closes #

## ⚠️ Checklist

- [X] The code is in the same pattern of the project
- [X] Update the docs (Only if needed)

## 📝 Comments

<!-- Add important notes to the revisor -->
